### PR TITLE
Add missing react preset

### DIFF
--- a/lessons/async-react.md
+++ b/lessons/async-react.md
@@ -85,6 +85,7 @@ Now make a file called `.babelrc` with the following:
 ```json
 {
   "presets": [
+    "react",
     [
       "env",
       {


### PR DESCRIPTION
Without the react preset, parcel throws an "Unexpected token" error because of the JSX code in App.js